### PR TITLE
Now isactive(RFParams) also checks if the RF frequency is non-zero.

### DIFF
--- a/src/rf.jl
+++ b/src/rf.jl
@@ -85,7 +85,7 @@ function Base.setproperty!(c::RFParams{T}, key::Symbol, value) where {T}
   error("RFParams does not have property $key")
 end
 
-isactive(rf::RFParams) = !(rf.voltage == 0)
+isactive(rf::RFParams) = !(rf.voltage == 0 && rf.rate == 0)
 
 
 # Note that it is currently impossible to derive harmonic number from frequency

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -870,8 +870,10 @@ using Test
     cav = RFCavity(rf_frequency=352e6, voltage=1e6)
     @test isactive(cav.RFParams)
     cav.voltage = 0
+    cav.rf_frequency = 0
     @test !isactive(cav.RFParams)
     cav.voltage=1e6
+    cav.rf_frequency=352e6
     @test isactive(cav.RFParams)
     @test cav.harmon_master == false && cav.rf_frequency == 352e6
     @test_throws ErrorException cav.harmon
@@ -890,7 +892,7 @@ using Test
     cav = CrabCavity(rf_frequency=352e6, voltage=1e6)
     @test isactive(cav.RFParams)
     cav.voltage = 0
-    @test !isactive(cav.RFParams)
+    @test isactive(cav.RFParams)
     cav.voltage=1e6
     @test isactive(cav.RFParams)
     @test cav.harmon_master == false && cav.rf_frequency == 352e6


### PR DESCRIPTION
Needed so that in BeamTracking the cavity code is called in case `dE_ref` is non-zero.
