### PR TITLE
Renamed `Lattice` to `Branch`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,13 @@
 name = "Beamlines"
 uuid = "5bb90b03-0719-46b8-8ce4-1ef3afd3cd4b"
 authors = ["Matt Signorelli <mgs255@cornell.edu> and contributors"]
-version = "0.8.14"
+version = "0.9.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 AtomicAndPhysicalConstants = "5c0d271c-5419-4163-b387-496237733d8b"
 EnumX = "4e289a0a-7415-4d19-859d-a7e5c4648b56"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 FunctionWrappers = "069b7b12-0de2-55c6-9aab-29f3d0a68a2e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
@@ -16,7 +17,6 @@ ReadOnlyArrays = "988b38a3-91fc-5605-94a2-ee2116b3bd83"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
-ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GTPSA = "b27dd330-f138-47c5-815b-40db9dd9b6e8"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"

--- a/README.md
+++ b/README.md
@@ -197,10 +197,10 @@ qf2.Kn1 == 0.1 # true
 # A Beamline has a single E_ref, p_over_q_ref, or pc_ref, and 
 # a single Species. One could also specify a single 
 # dE_ref, dp_over_q_ref, dpc_ref wrt the previous Beamline, granted 
-# the Beamlines are in a Lattice
+# the Beamlines are in a Branch
 bl1 = Beamline(LineElement[]; E_ref=10e9, species_ref=Species("proton"))
 bl2 = Beamline(LineElement[]; dE_ref=-3e9, species_ref=Species("electron"))
-lat = Lattice([bl1, bl2])
+branch = Branch([bl1, bl2])
 
 # In this case, bl1.E_ref=10e9, bl2.E_ref=7e9
 # Whichever of E_ref, p_over_q_ref, pc_ref, dE_ref, dp_over_q_ref, or dpc_ref is 
@@ -213,16 +213,16 @@ bl1 = Beamline([ele1, ele2])
 bl1.E_ref == 10e9 # true
 bl1.species_ref == Species("proton") # true
 
-# To ease construction of Lattices, one can alternatively use the 
-# Lattice(::Vector{LineElement}) constructor, which will automatically
+# To ease construction of Branchs, one can alternatively use the 
+# Branch(::Vector{LineElement}) constructor, which will automatically
 ele1 = LineElement(E_ref=10e9, species_ref=Species("electron"))
 ele1a = LineElement()
 ele2 = LineElement(dE_ref=-3e9, species_ref=Species("proton"))
 ele2a = LineElement()
 ele2b = LineElement()
-lat = Lattice([ele1, ele1a, ele2, ele2a, ele2b])
-all(lat.beamlines[1].line .=== [ele1, ele1a]) # true
-all(lat.beamlines[2].line .=== [ele2, ele2a, ele2b]) # true
+branch = Branch([ele1, ele1a, ele2, ele2a, ele2b])
+all(branch.beamlines[1].line .=== [ele1, ele1a]) # true
+all(branch.beamlines[2].line .=== [ele2, ele2a, ele2b]) # true
 ele1.E_ref == 10e9 # true
 ele2.E_ref == 7e9 # true
 ```
@@ -232,4 +232,4 @@ All properties stored in `Beamline`s and `LineElement`s must be independent vari
 
 # Acknowledgements
 
-`Beamlines.jl` aims to provide the powerful lattice definitions enabled by [classic Bmad](github.com/bmad-sim/bmad-ecosystem), [`AcceleratorLattice.jl`](https://github.com/bmad-sim/AcceleratorLattice.jl), and the [Particle Accelerator Lattice Standard (PALS) project](https://github.com/campa-consortium/pals). The use of lazily-evaluated deferred expressions is inspired completely by [MAD-NG](https://github.com/MethodicalAcceleratorDesign/MAD-NG). This package would be a fragment of what it is today without all of these efforts.
+`Beamlines.jl` aims to provide the powerful branch definitions enabled by [classic Bmad](github.com/bmad-sim/bmad-ecosystem), [`AcceleratorBranch.jl`](https://github.com/bmad-sim/AcceleratorBranch.jl), and the [Particle Accelerator Branch Standard (PALS) project](https://github.com/campa-consortium/pals). The use of lazily-evaluated deferred expressions is inspired completely by [MAD-NG](https://github.com/MethodicalAcceleratorDesign/MAD-NG). This package would be a fragment of what it is today without all of these efforts.

--- a/ext/BeamlinesPythonCallExt/BeamlinesPythonCallExt.jl
+++ b/ext/BeamlinesPythonCallExt/BeamlinesPythonCallExt.jl
@@ -1,18 +1,18 @@
 module BeamlinesPythonCallExt
 using PythonCall
 using Beamlines: LineElement, Beamline
-import Beamlines: defconvert, Lattice
+import Beamlines: defconvert, Branch
 
 # Python objects are always converted to numbers
 defconvert(::Type{T}, f::Py) where {T} = pyconvert(Number, f)
-function Lattice(lbl::PyList)
+function Branch(lbl::PyList)
   lbl = collect(vec(lbl))
   if all(t->t isa LineElement, lbl)
-    return Lattice(convert(Vector{LineElement}, lbl))
+    return Branch(convert(Vector{LineElement}, lbl))
   elseif all(t->t isa Beamline, lbl)
-    return Lattice(convert(Vector{Beamline}, lbl))
+    return Branch(convert(Vector{Beamline}, lbl))
   else
-    error("Lattice array must only contain ONE of Either LineElement or Beamline types")
+    error("Branch array must only contain ONE of Either LineElement or Beamline types")
   end
 end
 

--- a/src/Beamlines.jl
+++ b/src/Beamlines.jl
@@ -38,7 +38,7 @@ export AbstractParams,
        Controller,
        Patch,
        set!,
-       Lattice,
+       Branch,
 
        deepcopy_no_beamline,
        

--- a/src/beamline.jl
+++ b/src/beamline.jl
@@ -1,18 +1,18 @@
-abstract type Branch end # Only subtype is Beamline
+abstract type AbstractBeamline end # Only subtype is Beamline
 
-struct _Lattice{T<:Branch}
+struct _Branch{T<:AbstractBeamline}
   beamlines::ReadOnlyVector{T,Vector{T}}
-  function _Lattice{T}(beamlines::Vector{T}) where {T<:Branch}
-    lat = new(ReadOnlyVector(beamlines))
+  function _Branch{T}(beamlines::Vector{T}) where {T<:AbstractBeamline}
+    branch = new(ReadOnlyVector(beamlines))
     for i in eachindex(beamlines)
       bl = beamlines[i]
-      if getfield(bl, :lattice_index) != -1
-        error("Beamline $i is already in another Lattice!")
+      if getfield(bl, :branch_index) != -1
+        error("Beamline $i is already in another Branch!")
       end
-      setfield!(bl, :lattice, lat)
-      setfield!(bl, :lattice_index, i)
+      setfield!(bl, :branch, branch)
+      setfield!(bl, :branch_index, i)
     end
-    return lat
+    return branch
   end
 end
 
@@ -50,13 +50,13 @@ end
   end
 end
 
-# The Beamline type is essentially an "expanded" lattice, as
+# The Beamline type is essentially an "expanded" branch, as
 # in there are no PreExpansionDirectives here anymore.
-@kwdef mutable struct Beamline <: Branch
+@kwdef mutable struct Beamline <: AbstractBeamline
   const line::ReadOnlyVector{LineElement, Vector{LineElement}}
   const species_ref::Species
-  lattice::_Lattice{Beamline} # This should be HARD to change, not allowed easily
-  lattice_index::Int          # This should be HARD to change, not allowed easily
+  branch::_Branch{Beamline} # This should be HARD to change, not allowed easily
+  branch_index::Int          # This should be HARD to change, not allowed easily
   ref_meaning::RefMeaning.T   # This should be HARD to change, not allowed easily
   ref # Will be nothing if not specified
 
@@ -86,7 +86,7 @@ end
       end
     end
 
-    bl = new(ReadOnlyVector(convert(Vector{LineElement}, vec(line))), species_ref, NULL_LATTICE, -1, RefMeaning.p_over_q_ref, nothing)
+    bl = new(ReadOnlyVector(convert(Vector{LineElement}, vec(line))), species_ref, NULL_BRANCH, -1, RefMeaning.p_over_q_ref, nothing)
 
     # Check if any are in a Beamline already
     for i in eachindex(bl.line)
@@ -95,7 +95,7 @@ end
         error("""Cannot construct Beamline: element $i contains an InitialBeamlineParams 
           which can only be placed in the first element of a Beamline. To include 
           reference energy/species changes in the middle of an accelerator, use the 
-          Lattice constructor instead which will automatically construct separate 
+          Branch constructor instead which will automatically construct separate 
           Beamlines for each InitialBeamlineParams.
         """)
       end
@@ -174,9 +174,9 @@ function Base.show(io::IO, bl::Beamline)
   println(io, " "*String(ref_meaning), " = ", ref)
   lines_used += 1
 
-  lattice_index = getfield(bl, :lattice_index)
-  if lattice_index != -1
-    println(io, " lattice_index", " = ", lattice_index)
+  branch_index = getfield(bl, :branch_index)
+  if branch_index != -1
+    println(io, " branch_index", " = ", branch_index)
     lines_used += 1
   end
 
@@ -225,10 +225,10 @@ function reverse_bl_construction!(bl::Beamline, idx)
   return
 end
 
-const Lattice = _Lattice{Beamline}
-const NULL_LATTICE = Lattice(Beamline[])
+const Branch = _Branch{Beamline}
+const NULL_BRANCH = Branch(Beamline[])
 
-function Lattice(
+function Branch(
   line::AbstractArray{<:LineElement};
   species_ref0::Species=Species(),
   E_ref0=nothing,
@@ -247,15 +247,15 @@ function Lattice(
 
   # Check if any elements already in Beamline
   if any(t->haskey(getfield(t, :pdict), BeamlineParams), line)
-    error("Unable to construct Lattice using Lattice(::Vector{LineElement}) constructor:
+    error("Unable to construct Branch using Branch(::Vector{LineElement}) constructor:
            at least one LineElement is already in a Beamline. Please use the 
-           Lattice(::Vector{Beamline}) constructor instead.")
+           Branch(::Vector{Beamline}) constructor instead.")
   end
   # Determine all indices with InitialBeamlineParams
   idxs = findall(t->haskey(getfield(t, :pdict), InitialBeamlineParams), line)
   # If none, then only single Beamline
   if length(idxs) == 0
-    return Lattice([Beamline(line; species_ref=species_ref0, kwarg_sym=>kwarg_val)])
+    return Branch([Beamline(line; species_ref=species_ref0, kwarg_sym=>kwarg_val)])
   end
 
   n_beamlines = length(idxs)
@@ -274,27 +274,27 @@ function Lattice(
       beamlines[i] = Beamline(line[idx0:idxf])
     end
   end
-  return Lattice(beamlines)
+  return Branch(beamlines)
 end
 
-Base.propertynames(::Beamline) = (:line, :ref_meaning, :ref, :lattice, :lattice_index, :p_over_q_ref, :E_ref, :pc_ref, :dp_over_q_ref, :dE_ref, :dpc_ref, :species_ref)
+Base.propertynames(::Beamline) = (:line, :ref_meaning, :ref, :branch, :branch_index, :p_over_q_ref, :E_ref, :pc_ref, :dp_over_q_ref, :dE_ref, :dpc_ref, :species_ref)
 
 function Base.getproperty(b::Beamline, key::Symbol)
   # Fast gets first, hopefully constant prop
-  if key in (:ref, :ref_meaning, :species_ref, :line, :lattice, :lattice_index)
+  if key in (:ref, :ref_meaning, :species_ref, :line, :branch, :branch_index)
     field = deval(getfield(b, key))
     if key == :ref && isnothing(field)
       #@warn "p_over_q_ref has not been set: using default value of NaN"
       error("Unable to get $key: ref of the Beamline has not been set")
     elseif key == :species_ref && isnullspecies(field)
-      latidx = getfield(b, :lattice_index)
-      if latidx == -1 || latidx == 1
+      branchidx = getfield(b, :branch_index)
+      if branchidx == -1 || branchidx == 1
         error("Unable to get species_ref: species_ref of the Beamline has not been set")
       else
-        return getfield(b, :lattice).beamlines[latidx-1].species_ref
+        return getfield(b, :branch).beamlines[branchidx-1].species_ref
       end
-    elseif key in (:lattice, :lattice_index) && (field == -1 || field === NULL_LATTICE)
-      error("Unable to get $key: Beamline is not in a Lattice")
+    elseif key in (:branch, :branch_index) && (field == -1 || field === NULL_BRANCH)
+      error("Unable to get $key: Beamline is not in a Branch")
     end
     return field
   elseif key in (:E_ref, :pc_ref, :p_over_q_ref, :dE_ref, :dpc_ref, :dp_over_q_ref)
@@ -330,15 +330,15 @@ function Base.getproperty(b::Beamline, key::Symbol)
             (key == :pc_ref && ref_meaning == :dpc_ref) || 
             (key == :p_over_q_ref && ref_meaning == :dp_over_q_ref)
           # Can just add going backwards
-          lat_idx = getfield(b, :lattice_index)
-          if lat_idx == -1
+          branch_idx = getfield(b, :branch_index)
+          if branch_idx == -1
             error("Unable to get property $key: because this Beamline has set $(ref_meaning),
-                    the property $key must be dependent on an upstream Beamline in a Lattice, but 
-                    the Beamline is not in a Lattice.")
-          elseif lat_idx == 1
+                    the property $key must be dependent on an upstream Beamline in a Branch, but 
+                    the Beamline is not in a Branch.")
+          elseif branch_idx == 1
             return b.ref # Basically just assume zero for all "before" if first Beamline (out of thin air)
           else
-            return b.ref + getproperty(b.lattice.beamlines[b.lattice_index-1], key)
+            return b.ref + getproperty(b.branch.beamlines[b.branch_index-1], key)
           end
         elseif key == :E_ref
           if ref_meaning == :dpc_ref
@@ -362,20 +362,20 @@ function Base.getproperty(b::Beamline, key::Symbol)
       end
     else
       # Key relative
-      lat_idx = getfield(b, :lattice_index)
-      if lat_idx == -1
+      branch_idx = getfield(b, :branch_index)
+      if branch_idx == -1
         error("Unable to get property $key: because this Beamline has set $(ref_meaning),
-                the property $key must be dependent on an upstream Beamline in a Lattice, but 
-                the Beamline is not in a Lattice.")
-      elseif lat_idx == 1
+                the property $key must be dependent on an upstream Beamline in a Branch, but 
+                the Beamline is not in a Branch.")
+      elseif branch_idx == 1
         return b.ref # Basically just assume zero for all "before" if first Beamline (out of thin air)
       else
         if key == :dE_ref
-          return b.E_ref - b.lattice.beamlines[b.lattice_index-1].E_ref
+          return b.E_ref - b.branch.beamlines[b.branch_index-1].E_ref
         elseif key == :dpc_ref
-          return b.pc_ref - b.lattice.beamlines[b.lattice_index-1].pc_ref
+          return b.pc_ref - b.branch.beamlines[b.branch_index-1].pc_ref
         else
-          return b.p_over_q_ref - b.lattice.beamlines[b.lattice_index-1].p_over_q_ref
+          return b.p_over_q_ref - b.branch.beamlines[b.branch_index-1].p_over_q_ref
         end
       end
     end
@@ -388,7 +388,7 @@ end
 function Base.setproperty!(b::Beamline, key::Symbol, value)
   if key in (:ref, :species_ref, :line)
     return setfield!(b, key, value)
-  elseif key in (:lattice, :lattice_index, :ref_meaning)
+  elseif key in (:branch, :branch_index, :ref_meaning)
     error("Unable to set property $key: this field is protected")
   elseif key in (:E_ref, :pc_ref, :dp_over_q_ref, :dE_ref, :dpc_ref)
     setfield!(b, :ref_meaning, sym_to_refmeaning(key))
@@ -439,9 +439,9 @@ function Base.show(io::IO, bp::BeamlineParams)
   println(io, rpad(" s",width), " = ", bp.s)
   println(io, rpad(" s_downstream",width), " = ", bp.s_downstream)
 
-  lattice_index = getfield(bp.beamline, :lattice_index)
-  if lattice_index != -1
-    println(io, rpad(" lattice_index", width), " = ", lattice_index)
+  branch_index = getfield(bp.beamline, :branch_index)
+  if branch_index != -1
+    println(io, rpad(" branch_index", width), " = ", branch_index)
   end
 
   return
@@ -450,7 +450,7 @@ end
 # Make E_ref and p_over_q_ref (in beamline) be properties
 # Also make s a property of BeamlineParams
 # Note that because BeamlineParams is immutable, not setting rn
-Base.propertynames(::BeamlineParams) = (:beamline, :beamline_index, :s, :s_downstream, :p_over_q_ref, :E_ref, :pc_ref, :dp_over_q_ref, :dE_ref, :dpc_ref, :species_ref, :lattice, :lattice_index)
+Base.propertynames(::BeamlineParams) = (:beamline, :beamline_index, :s, :s_downstream, :p_over_q_ref, :E_ref, :pc_ref, :dp_over_q_ref, :dE_ref, :dpc_ref, :species_ref, :branch, :branch_index)
 
 function Base.setproperty!(bp::BeamlineParams, key::Symbol, value)
   # only settable at first element
@@ -461,7 +461,7 @@ function Base.setproperty!(bp::BeamlineParams, key::Symbol, value)
       error("Property $key is a Beamline property, and therefore is only settable at 
             at the first element in a Beamline Consider setting $key at the Beamline 
             level (e.g. beamline.$key = $value), or setting this parameter in an element 
-            prior to Lattice construction to automatically generate a separate Beamline.")
+            prior to Branch construction to automatically generate a separate Beamline.")
     end
   else
     return setproperty!(bp.beamline, key, value)
@@ -484,7 +484,7 @@ end
 =#
 
 function Base.getproperty(bp::BeamlineParams, key::Symbol)
-  if key in (:p_over_q_ref, :E_ref, :pc_ref, :species_ref, :lattice, :lattice_index, :ref)
+  if key in (:p_over_q_ref, :E_ref, :pc_ref, :species_ref, :branch, :branch_index, :ref)
     return deval(getproperty(bp.beamline, key))
   elseif key in (:dp_over_q_ref, :dE_ref, :dpc_ref)
     if bp.beamline_index != 1
@@ -586,7 +586,7 @@ function Base.getproperty(ibp::InitialBeamlineParams, key::Symbol)
       end
     else
       error("Unable to get property $key: InitialBeamlineParams has stored $(ibp.ref_meaning), and
-            so property $key depends on an upstream Lattice which has not been constructed yet.")
+            so property $key depends on an upstream Branch which has not been constructed yet.")
     end
   end
   error("This error is unreachable. If reached, submit an issue to Beamlines")

--- a/src/keymaps.jl
+++ b/src/keymaps.jl
@@ -39,8 +39,8 @@ const PROPERTIES_MAP = Dict{Symbol,Type{<:AbstractParams}}(
   :dpc_ref => BeamlineParams, 
   :species_ref => BeamlineParams,
   =#
-  :lattice => BeamlineParams,
-  :lattice_index => BeamlineParams,
+  :branch => BeamlineParams,
+  :branch_index => BeamlineParams,
   :s => BeamlineParams,
   :s_downstream => BeamlineParams,
 

--- a/src/multipole.jl
+++ b/src/multipole.jl
@@ -1,7 +1,7 @@
 """
     struct BMultipoleParams{T,N} <: AbstractParams
 
-Structure holding the magnetic multipole components of a lattice element. 
+Structure holding the magnetic multipole components of a branch element. 
 
 ## Fields
 

--- a/src/scalarize.jl
+++ b/src/scalarize.jl
@@ -33,13 +33,13 @@ function scalarize!(bl::Beamline)
 end
 
 """
-    scalarize!(lat::Lattice)
+    scalarize!(branch::Branch)
 
-Modifies the Lattice so all LineElement and Beamline parameters are scalars.
+Modifies the Branch so all LineElement and Beamline parameters are scalars.
 """
-function scalarize!(lat::Lattice)
-    for bl in lat.beamlines
+function scalarize!(branch::Branch)
+    for bl in branch.beamlines
         scalarize!(bl)
     end
-    return lat
+    return branch
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1172,14 +1172,14 @@ using ForwardDiff, GTPSA, ReverseDiff
     bl.ref = 4.0
     @test bl.ref == 4.0
 
-    # Lattices now
+    # Branchs now
     bl1 = Beamline(LineElement[]; E_ref=10e9, species_ref=Species("electron"))
     bl2 = Beamline(LineElement[]; dE_ref=-3e9, species_ref=Species("proton"))
     @test_throws ErrorException bl1.dE_ref
     @test_throws ErrorException bl2.dpc_ref
     @test_throws ErrorException bl2.dp_over_q_ref
     @test bl2.dE_ref == -3e9
-    lat = Lattice([bl1, bl2])
+    branch = Branch([bl1, bl2])
     @test bl2.E_ref == 7e9
     @test bl2.species_ref == Species("proton")
     @test bl2.dE_ref == -3e9
@@ -1211,27 +1211,27 @@ using ForwardDiff, GTPSA, ReverseDiff
     @test bl2.p_over_q_ref - bl1.p_over_q_ref ≈ bl2.dp_over_q_ref
 
     @test_throws ErrorException Beamline(LineElement[]; pc_ref=1, dp_over_q_ref=2)
-    @test_throws ErrorException Beamline(LineElement[]).lattice
-    @test (bl = Beamline(LineElement[]; E_ref=10); lat = Lattice([bl]); bl.dE_ref) == 10
-    @test_throws ErrorException Beamline(LineElement[]).lattice_index = 1
-    @test_throws ErrorException Beamline(LineElement[]).lattice = Beamlines.NULL_LATTICE
+    @test_throws ErrorException Beamline(LineElement[]).branch
+    @test (bl = Beamline(LineElement[]; E_ref=10); branch = Branch([bl]); bl.dE_ref) == 10
+    @test_throws ErrorException Beamline(LineElement[]).branch_index = 1
+    @test_throws ErrorException Beamline(LineElement[]).branch = Beamlines.NULL_BRANCH
     @test_throws ErrorException Beamline(LineElement[]).ref_meaning = Beamlines.RefMeaning.p_over_q_ref
     
     bl = Beamline(LineElement[])
-    lat = Lattice([bl])
-    @test_throws ErrorException Lattice([bl])
+    branch = Branch([bl])
+    @test_throws ErrorException Branch([bl])
 
-    @test Lattice([Beamline(LineElement[]; dp_over_q_ref=10.)]).beamlines[1].p_over_q_ref == 10.
+    @test Branch([Beamline(LineElement[]; dp_over_q_ref=10.)]).beamlines[1].p_over_q_ref == 10.
 
-    # Lattice LineElement ctor:
+    # Branch LineElement ctor:
     ele1 = LineElement(E_ref=10e9, species_ref=Species("electron"))
     ele1a = LineElement()
     ele2 = LineElement(dE_ref=-3e9, species_ref=Species("proton"))
     ele2a = LineElement()
     ele2b = LineElement()
-    lat = Lattice([ele1, ele1a, ele2, ele2a, ele2b])
-    @test all(lat.beamlines[1].line .=== [ele1, ele1a])
-    @test all(lat.beamlines[2].line .=== [ele2, ele2a, ele2b])
+    branch = Branch([ele1, ele1a, ele2, ele2a, ele2b])
+    @test all(branch.beamlines[1].line .=== [ele1, ele1a])
+    @test all(branch.beamlines[2].line .=== [ele2, ele2a, ele2b])
     bl1 = ele1.beamline
     bl2 = ele2.beamline
     @test bl2.E_ref == 7e9
@@ -1265,8 +1265,8 @@ using ForwardDiff, GTPSA, ReverseDiff
     # Check that InitialBeamlineParams is overridden:
     ele1 = LineElement(E_ref=10e9, species_ref=Species("electron"))
     ele1a = LineElement()
-    lat = Lattice([ele1, ele1a]; species_ref0=Species("proton"), E_ref0=20e9)
-    @test all(lat.beamlines[1].line .=== [ele1, ele1a])
+    branch = Branch([ele1, ele1a]; species_ref0=Species("proton"), E_ref0=20e9)
+    @test all(branch.beamlines[1].line .=== [ele1, ele1a])
     bl1 = ele1.beamline
     @test bl1.E_ref == 20e9
     @test bl1.species_ref == Species("proton")
@@ -1276,23 +1276,23 @@ using ForwardDiff, GTPSA, ReverseDiff
     ele2 = LineElement(dE_ref=-3e9, species_ref=Species("proton"))
     ele2a = LineElement()
     ele2b = LineElement()
-    lat = Lattice([ele1, ele1a, ele2, ele2a, ele2b]; species_ref0=Species("proton"), E_ref0=20e9)
-    @test all(lat.beamlines[1].line .=== [ele1, ele1a])
-    @test all(lat.beamlines[2].line .=== [ele2, ele2a, ele2b])
+    branch = Branch([ele1, ele1a, ele2, ele2a, ele2b]; species_ref0=Species("proton"), E_ref0=20e9)
+    @test all(branch.beamlines[1].line .=== [ele1, ele1a])
+    @test all(branch.beamlines[2].line .=== [ele2, ele2a, ele2b])
     bl1 = ele1.beamline
     bl2 = ele2.beamline
     @test bl1.E_ref == 20e9
     @test bl1.species_ref == Species("proton")
 
 
-    lat = Lattice([LineElement(), LineElement()]; species_ref0=Species("proton"), E_ref0=10e9)
-    @test lat.beamlines[1].E_ref == 10e9
-    @test lat.beamlines[1].species_ref == Species("proton")
+    branch = Branch([LineElement(), LineElement()]; species_ref0=Species("proton"), E_ref0=10e9)
+    @test branch.beamlines[1].E_ref == 10e9
+    @test branch.beamlines[1].species_ref == Species("proton")
 
     ele1 = LineElement()
     bl1 = Beamline([ele1])
-    @test_throws ErrorException Lattice([ele1])
-    @test_throws ErrorException Lattice(LineElement[]; E_ref0=10e9, pc_ref0=3e9)
+    @test_throws ErrorException Branch([ele1])
+    @test_throws ErrorException Branch(LineElement[]; E_ref0=10e9, pc_ref0=3e9)
 
     # MapParams
     f = (v,q=nothing)->((1,2,3,4,5,6),(7,8,9,10))
@@ -1401,7 +1401,7 @@ using ForwardDiff, GTPSA, ReverseDiff
     d = Drift(L=5.0)
     qd = Quadrupole(Kn1=-0.36, L=0.5)
     fodo = Beamline([qf, d, qd, d])
-    lat = Lattice([fodo])
+    branch = Branch([fodo])
 
     for (adnum,num) in zip(adnums,nums)
       qf.Kn1 = adnum
@@ -1420,7 +1420,7 @@ using ForwardDiff, GTPSA, ReverseDiff
       qf.Kn1 = adnum
       d.L = adnum
       fodo.ref = adnum
-      scalarize!(lat)
+      scalarize!(branch)
       @test fodo.ref isa Float64
       @test d.L isa Float64
       @test qf.Kn1 isa Float64
@@ -1432,12 +1432,12 @@ using ForwardDiff, GTPSA, ReverseDiff
       @test fodo.ref == num
     end
 
-    # test inherit species lattice
+    # test inherit species branch
     q2 = Drift(L = 1, dE_ref=1e6)
     m2 = Marker(E_ref = 10e9, species_ref=Species("electron"))
-    lat2 = Lattice([m2, q2])
+    branch2 = Branch([m2, q2])
     @test q2.species_ref == m2.species_ref
-    @test lat2.beamlines[1].species_ref == lat2.beamlines[2].species_ref
+    @test branch2.beamlines[1].species_ref == branch2.beamlines[2].species_ref
 
 
     # Deepcopy ignores BeamlineParams


### PR DESCRIPTION
@mattsignorelli I did not define a new `Lattice` struct that is an array of `Branches` since I was not exactly sure how to do it here and I figured you could do it a lot faster. There is a corresponding BeamTracking PR being posted shortly.