### PR TITLE
Construct DefExpr from Python callables in PythonCall extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -48,8 +48,9 @@ julia = "1.10"
 [extras]
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 GTPSA = "b27dd330-f138-47c5-815b-40db9dd9b6e8"
+PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "ForwardDiff", "GTPSA", "ReverseDiff"]
+test = ["Test", "ForwardDiff", "GTPSA", "ReverseDiff", "PythonCall"]

--- a/ext/BeamlinesPythonCallExt/BeamlinesPythonCallExt.jl
+++ b/ext/BeamlinesPythonCallExt/BeamlinesPythonCallExt.jl
@@ -1,7 +1,7 @@
 module BeamlinesPythonCallExt
 using PythonCall
-using Beamlines: LineElement, Beamline
-import Beamlines: defconvert, Branch
+using Beamlines: LineElement, Beamline, Context
+import Beamlines: defconvert, Branch, DefExpr
 
 # Python objects are always converted to numbers
 defconvert(::Type{T}, f::Py) where {T} = pyconvert(Number, f)
@@ -15,5 +15,63 @@ function Branch(lbl::PyList)
     error("Branch array must only contain ONE of Either LineElement or Beamline types")
   end
 end
+
+# --- DefExpr construction from Python callables ------------------------------
+#
+# A `DefExpr` wraps a lambda that is either 0-argument or accepts a `Context`.
+# The generic `DefExpr(f)` constructor decides between these by inspecting
+# `applicable(f)`, which cannot distinguish them for a `Py`: juliacall makes
+# every `Py` callable with any number of arguments, so `applicable(f)` is always
+# true and the 0-argument branch is always taken. Here we inspect the Python
+# signature instead, so both
+#
+#     DefExpr(lambda: a)        # 0-argument
+#     DefExpr(lambda c: c.k1)   # Context-accepting
+#
+# build the correct expression, closing over the real `Context` at evaluation
+# time. A plain Python value (e.g. `DefExpr(0.36)`) is also accepted.
+
+_pycallable(f::Py) = pytruth(pybuiltins.callable(f))
+
+# Number of required positional parameters of a Python callable (0 or >=1).
+function _py_positional_arity(f::Py)
+  inspect = pyimport("inspect")
+  local sig
+  try
+    sig = inspect.signature(f)
+  catch
+    return 1  # cannot introspect (e.g. some builtins); assume it takes a Context
+  end
+  Parameter = inspect.Parameter
+  n = 0
+  for p in sig.parameters.values()
+    kind = p.kind
+    if pyeq(Bool, kind, Parameter.VAR_POSITIONAL)
+      return 1  # *args can absorb the Context
+    end
+    is_positional = pyeq(Bool, kind, Parameter.POSITIONAL_ONLY) ||
+                    pyeq(Bool, kind, Parameter.POSITIONAL_OR_KEYWORD)
+    has_default = !pyeq(Bool, p.default, Parameter.empty)
+    if is_positional && !has_default
+      n += 1
+    end
+  end
+  return n
+end
+
+function DefExpr{T}(f::Py) where {T}
+  if _pycallable(f)
+    if _py_positional_arity(f) == 0
+      return DefExpr{T}(() -> pyconvert(T, f()))
+    else
+      return DefExpr{T}((c::Context) -> pyconvert(T, f(c)))
+    end
+  else
+    return DefExpr{T}(pyconvert(T, f))  # a plain Python value
+  end
+end
+
+# Untyped convenience: Python numeric parameters are Float64 by default.
+DefExpr(f::Py) = DefExpr{Float64}(f)
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Beamlines
 using Beamlines: isactive
 using Test
 using ForwardDiff, GTPSA, ReverseDiff
+using PythonCall
 
 @testset "Beamlines.jl" begin
     L = 5.0f0
@@ -1556,4 +1557,30 @@ using ForwardDiff, GTPSA, ReverseDiff
     @test bl[ele][1].L == 5
     bl.context = c
     @test bl[ele][1].L == 6
+end
+
+# Exercises BeamlinesPythonCallExt: building a DefExpr from a Python callable or
+# value. Requires PythonCall (which provisions Python via CondaPkg on first use).
+@testset "BeamlinesPythonCallExt (DefExpr from Python)" begin
+    # 0-argument callable
+    @test DefExpr(pyeval(Py, "lambda: 1.0", Main))() == 1.0
+
+    # Context-accepting callable, closing over the real Context at evaluation time
+    dctx = DefExpr(pyeval(Py, "lambda c: c.k1", Main))
+    @test dctx(Context(k1 = 0.36)) == 0.36
+
+    # plain Python value
+    @test DefExpr(pyeval(Py, "0.5", Main))() == 0.5
+
+    # *args absorbs the Context (arity treated as >= 1)
+    @test DefExpr(pyeval(Py, "lambda *a: 2.0", Main))(Context(k1 = 0.0)) == 2.0
+
+    # a defaulted parameter is not "required" -> 0-argument form
+    @test DefExpr(pyeval(Py, "lambda x=1: 3.0", Main))() == 3.0
+
+    # a callable whose signature cannot be introspected still constructs
+    @test DefExpr(pyeval(Py, "print", Main)) isa DefExpr
+
+    # operator overloading composes through the existing DefExpr operators
+    @test (DefExpr(pyeval(Py, "lambda: 1.0", Main)) + 10)() == 11.0
 end


### PR DESCRIPTION
Part of the Python-interface work for bmad-sim/SciBmad.jl#76.

## What

Adds `DefExpr{T}(::Py)` / `DefExpr(::Py)` to `BeamlinesPythonCallExt`, so a deferred expression can be built from a Python callable or value:

```python
DefExpr(lambda: a)        # 0-argument
DefExpr(lambda c: c.k1)   # Context-accepting
DefExpr(0.36)             # plain value
```

## Why

The generic `DefExpr(f)` constructor chooses the 0-arg vs `Context`-accepting form using `applicable(f)`. That check cannot distinguish the two cases for a `Py`: juliacall makes every `Py` callable with any number of arguments, so `applicable(f)` is always `true` and the 0-argument branch is always taken (discarding the `Context`). This inspects the Python signature (`inspect.signature`) instead, so:

- a 0-parameter callable becomes a 0-arg expression,
- a callable with a required positional parameter becomes a `Context`-accepting expression that closes over the **real** `Context` at evaluation time,
- a non-callable becomes a constant expression.

Keeps all Python-specific handling inside the existing PythonCall extension, per #76.

## Scope

- No change to any non-`Py` method — the new methods dispatch only on `::Py`.
- Untyped `DefExpr(::Py)` defaults to `Float64` (Python numeric parameters).

## Testing

Verified via juliacall (with `Beamlines` + `PythonCall` dev-loaded) that all three forms above build and evaluate correctly, including `DefExpr(lambda c: c.k1)` against a `Context(k1=0.36)`, and that `DefExpr(...) + 10` composes through the existing operators. Opened as a **draft** — I could not run the full Beamlines.jl CI locally. A test exercising this belongs in `test/runtests.jl` under a `PythonCall` target if the maintainers want it here.